### PR TITLE
Media replacement && Mogrt Group fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 .DS_Store
+.vscode
+.pretrtierignore
+.example

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This plugin adds .mogrt support to Nexrender.
 2. Add this module in predownload actions
 3. Add any Essential Graphics parameters you want to change as `essentialParameters`
 
-
 ```json
 {
     "template": {
@@ -25,6 +24,7 @@ This plugin adds .mogrt support to Nexrender.
                 "module": "nexrender-action-mogrt-template",
                 "essentialParameters": {
                     "Title": "This should be the title",
+                    "Image": "file:///path/to/image.png",
                     "Dropdown": 2,
                     "Scale": [50, 50],
                     "Checkbox": true,
@@ -35,13 +35,15 @@ This plugin adds .mogrt support to Nexrender.
                     "Scale": [50, 50]
                 }
             }
-        ],
-
+        ]
+    }
+}
 ```
 
 ## Notes
 
-* Any `template.src` without a .mogrt extension will be ignored
-* The value in `template.composition` will be ignored, as .mogrt files specify what composition to use on their own, but Nexrender requires one to be specified
-* Media replacement through essential graphics isn't supported (yet), but normal asset injection with Nexrender will work
-* Invalid .mogrt files will cause an error
+-   Any `template.src` without a .mogrt extension will be ignored
+-   The value in `template.composition` will be ignored, as .mogrt files specify what composition to use on their own, but Nexrender requires one to be specified
+-   Like Nexrender, Medias are expected to use the file Url format.
+-   Invalid .mogrt files will cause an error
+

--- a/applyEssentialValues.jsx
+++ b/applyEssentialValues.jsx
@@ -1,7 +1,14 @@
 (function () {
     function emptyDuplicate(comp, name) {
-        name = name || ('empty ' + comp.name);
-        return app.project.items.addComp(name, comp.width, comp.height, comp.pixelAspect, comp.duration, comp.frameRate);
+        name = name || 'empty ' + comp.name;
+        return app.project.items.addComp(
+            name,
+            comp.width,
+            comp.height,
+            comp.pixelAspect,
+            comp.duration,
+            comp.frameRate
+        );
     }
 
     function compByName(name) {
@@ -13,16 +20,48 @@
         }
     }
 
-    const compName = typeof _essential !== 'undefined' && _essential.get('composition') || 'Comp 1';
-    const essentialParameters = typeof _essential !== 'undefined' && _essential.get('essentialParameters') || {};
-    const templateComp = compByName(compName);
-    const comp = emptyDuplicate(templateComp, "__mogrt__");
+    function getAllProperties(prop, props) {
+        for (var i = 1; i <= prop.numProperties; i++) {
+            var currentProp = prop.property(i);
+            if (currentProp.numProperties > 0) {
+                getAllProperties(currentProp, props);
+            } else {
+                props.push(currentProp);
+            }
+        }
+        return props;
+    }
+
+    var compName =
+        (typeof _essential !== 'undefined' && _essential.get('composition')) ||
+        'Comp 1';
+    var essentialParameters =
+        (typeof _essential !== 'undefined' &&
+            _essential.get('essentialParameters')) ||
+        {};
+
+    var templateComp = compByName(compName);
+    var comp = emptyDuplicate(templateComp, '__mogrt__');
     var layer = comp.layers.add(templateComp);
-    for (var i = 1; i <= layer.essentialProperty.numProperties; i++) {
-        var prop = layer.essentialProperty(i);
+    var layer = comp.layers.add(templateComp);
+    var essentialProperty = layer.essentialProperty;
+    var essentialProperties = getAllProperties(essentialProperty, [
+        essentialProperty,
+    ]);
+
+    for (var p = 0; p < essentialProperties.length; p++) {
+        var prop = essentialProperties[p];
         var value = essentialParameters[prop.name];
-        if (typeof value !== "undefined") {
-            prop.setValue(value)
+        if (typeof value !== 'undefined') {
+            if (prop.canSetAlternateSource) {
+                var replacementItem = app.project.importFile(
+                    new ImportOptions(new File(value))
+                );
+                prop.setAlternateSource(replacementItem);
+            } else {
+                prop.setValue(value);
+            }
         }
     }
 })();
+

--- a/index.js
+++ b/index.js
@@ -4,67 +4,81 @@ const url = require('url');
 const fs = require('fs/promises');
 
 module.exports = async (job, settings, options, type) => {
-    settings.logger = settings.logger ?? console;
-    const jsxUrl = url.pathToFileURL(path.join(__dirname, 'applyEssentialValues.jsx')).toString();
-    if (type === 'predownload') {
-        if (typeof options.essentialParameters !== 'undefined') {
-            job.assets.push({
-                src: jsxUrl,
-                keyword: '_essential',
-                type: 'script',
-                parameters: [
-                    {
-                        key: 'essentialParameters',
-                        value: Object.assign({}, options.essentialParameters)
-                    }
-                ]
-            })
-        }
-
-        // self-add this module as prerender action as well
-        if (!job.actions.prerender) {
-            job.actions.prerender = [];
-        }
-        job.actions.prerender.push({...options,
-            module: __filename,
-            automaticallyAdded: true
-        });
-        job.template.composition = '__mogrt__';
-        return job;
-    } else if (type === 'prerender' && options.automaticallyAdded) {
-        if(path.extname(job.template.dest).toLowerCase() !== ".mogrt"){
-            settings.logger.log(`[${job.uid}] [action-mogrt-template] skipping - template file should have .mogrt extension`);
-            return job;
-        }    
-
-        const { Mogrt } = await import('mogrt');
-        const mogrt = new Mogrt(job.template.dest);
-        await mogrt.init();
-
-        if (!mogrt.isAfterEffects()) {
-            throw Error('[action-mogrt-template] ERROR - .mogrt was not made with After Effects');
-        }
-        const manifest = await mogrt.getManifest();
-        const compName = manifest.sourceInfoLocalized.en_US.name;
-
-        const asset = job.assets.find(a => a.src === jsxUrl);
-        asset.parameters.push({
-            key: 'composition',
-            value: compName
-        });
-        
-        const filenames = await mogrt.extractTo(job.workpath);
-        const template = filenames.find(fn => path.extname(fn).toLowerCase() === '.aep');
-        if (!template) {
-            throw Error(`[${job.uid}] [action-mogrt-template] ERROR - no AE file found in the .mogrt (extension .aep)`);
-        }
-
-        settings.logger.log(`[${job.uid}] [action-mogrt-template] setting new template path to: ${template}`);
-
-        job.template.dest = template;
-        job.template.extension = "aep";
-        return job;
-    } else {
-        throw Error("'action-mogrt-template' module should be used only in 'predownload' section");
+  settings.logger = settings.logger ?? console;
+  const jsxUrl = url
+    .pathToFileURL(path.join(__dirname, 'applyEssentialValues.jsx'))
+    .toString();
+  if (type === 'predownload') {
+    if (typeof options.essentialParameters !== 'undefined') {
+      job.assets.push({
+        src: jsxUrl,
+        keyword: '_essential',
+        type: 'script',
+        parameters: [
+          {
+            key: 'essentialParameters',
+            value: Object.assign({}, options.essentialParameters),
+          },
+        ],
+      });
     }
-}
+
+    // self-add this module as prerender action as well
+    if (!job.actions.prerender) {
+      job.actions.prerender = [];
+    }
+    job.actions.prerender.push({
+      ...options,
+      module: __filename,
+      automaticallyAdded: true,
+    });
+    job.template.composition = '__mogrt__';
+    return job;
+  } else if (type === 'prerender' && options.automaticallyAdded) {
+    if (path.extname(job.template.dest).toLowerCase() !== '.mogrt') {
+      settings.logger.log(
+        `[${job.uid}] [action-mogrt-template] skipping - template file should have .mogrt extension`
+      );
+      return job;
+    }
+
+    const { Mogrt } = await import('mogrt');
+    const mogrt = new Mogrt(job.template.dest);
+    await mogrt.init();
+
+    if (!mogrt.isAfterEffects()) {
+      throw Error(
+        '[action-mogrt-template] ERROR - .mogrt was not made with After Effects'
+      );
+    }
+    const manifest = await mogrt.getManifest();
+    const compName = manifest.sourceInfoLocalized.en_US.name;
+    const asset = job.assets.find((a) => a.src === jsxUrl);
+    asset.parameters.push({
+      key: 'composition',
+      value: compName,
+    });
+
+    const filenames = await mogrt.extractTo(job.workpath);
+    const template = filenames.find(
+      (fn) => path.extname(fn).toLowerCase() === '.aep'
+    );
+    if (!template) {
+      throw Error(
+        `[${job.uid}] [action-mogrt-template] ERROR - no AE file found in the .mogrt (extension .aep)`
+      );
+    }
+
+    settings.logger.log(
+      `[${job.uid}] [action-mogrt-template] setting new template path to: ${template}`
+    );
+
+    job.template.dest = template;
+    job.template.extension = 'aep';
+    return job;
+  } else {
+    throw Error(
+      "'action-mogrt-template' module should be used only in 'predownload' section"
+    );
+  }
+};

--- a/index.js
+++ b/index.js
@@ -1,84 +1,92 @@
-const StreamZip = require('node-stream-zip');
 const path = require('path');
 const url = require('url');
-const fs = require('fs/promises');
 
 module.exports = async (job, settings, options, type) => {
-  settings.logger = settings.logger ?? console;
-  const jsxUrl = url
-    .pathToFileURL(path.join(__dirname, 'applyEssentialValues.jsx'))
-    .toString();
-  if (type === 'predownload') {
-    if (typeof options.essentialParameters !== 'undefined') {
-      job.assets.push({
-        src: jsxUrl,
-        keyword: '_essential',
-        type: 'script',
-        parameters: [
-          {
-            key: 'essentialParameters',
-            value: Object.assign({}, options.essentialParameters),
-          },
-        ],
-      });
+    settings.logger = settings.logger ?? console;
+    const jsxUrl = url
+        .pathToFileURL(path.join(__dirname, 'applyEssentialValues.jsx'))
+        .toString();
+    if (type === 'predownload') {
+        if (typeof options.essentialParameters !== 'undefined') {
+            for (const [key, value] of Object.entries(
+                options.essentialParameters
+            )) {
+                if (typeof value == 'string' && value.match('file://')) {
+                    options.essentialParameters[key] = url.fileURLToPath(value);
+                }
+            }
+            console.group(options.essentialParameters);
+
+            job.assets.push({
+                src: jsxUrl,
+                keyword: '_essential',
+                type: 'script',
+                parameters: [
+                    {
+                        key: 'essentialParameters',
+                        value: Object.assign({}, options.essentialParameters),
+                    },
+                ],
+            });
+        }
+
+        // self-add this module as prerender action as well
+        if (!job.actions.prerender) {
+            job.actions.prerender = [];
+        }
+        job.actions.prerender.push({
+            ...options,
+            module: __filename,
+            automaticallyAdded: true,
+        });
+        job.template.composition = '__mogrt__';
+        return job;
+    } else if (type === 'prerender' && options.automaticallyAdded) {
+        if (path.extname(job.template.dest).toLowerCase() !== '.mogrt') {
+            settings.logger.log(
+                `[${job.uid}] [action-mogrt-template] skipping - template file should have .mogrt extension`
+            );
+            return job;
+        }
+
+        const { Mogrt } = await import('mogrt');
+        const mogrt = new Mogrt(job.template.dest);
+        await mogrt.init();
+
+        if (!mogrt.isAfterEffects()) {
+            throw Error(
+                '[action-mogrt-template] ERROR - .mogrt was not made with After Effects'
+            );
+        }
+        const manifest = await mogrt.getManifest();
+        const compName = manifest.sourceInfoLocalized.en_US.name;
+        const asset = job.assets.find((a) => a.src === jsxUrl);
+        asset.parameters.push({
+            key: 'composition',
+            value: compName,
+        });
+
+        const filenames = await mogrt.extractTo(job.workpath);
+        const template = filenames.find(
+            (fn) => path.extname(fn).toLowerCase() === '.aep'
+        );
+        if (!template) {
+            throw Error(
+                `[${job.uid}] [action-mogrt-template] ERROR - no AE file found in the .mogrt (extension .aep)`
+            );
+        }
+
+        settings.logger.log(
+            `[${job.uid}] [action-mogrt-template] setting new template path to: ${template}`
+        );
+
+        job.template.dest = template;
+        job.template.extension = 'aep';
+        return job;
+    } else {
+        throw Error(
+            "'action-mogrt-template' module should be used only in 'predownload' section"
+        );
     }
-
-    // self-add this module as prerender action as well
-    if (!job.actions.prerender) {
-      job.actions.prerender = [];
-    }
-    job.actions.prerender.push({
-      ...options,
-      module: __filename,
-      automaticallyAdded: true,
-    });
-    job.template.composition = '__mogrt__';
-    return job;
-  } else if (type === 'prerender' && options.automaticallyAdded) {
-    if (path.extname(job.template.dest).toLowerCase() !== '.mogrt') {
-      settings.logger.log(
-        `[${job.uid}] [action-mogrt-template] skipping - template file should have .mogrt extension`
-      );
-      return job;
-    }
-
-    const { Mogrt } = await import('mogrt');
-    const mogrt = new Mogrt(job.template.dest);
-    await mogrt.init();
-
-    if (!mogrt.isAfterEffects()) {
-      throw Error(
-        '[action-mogrt-template] ERROR - .mogrt was not made with After Effects'
-      );
-    }
-    const manifest = await mogrt.getManifest();
-    const compName = manifest.sourceInfoLocalized.en_US.name;
-    const asset = job.assets.find((a) => a.src === jsxUrl);
-    asset.parameters.push({
-      key: 'composition',
-      value: compName,
-    });
-
-    const filenames = await mogrt.extractTo(job.workpath);
-    const template = filenames.find(
-      (fn) => path.extname(fn).toLowerCase() === '.aep'
-    );
-    if (!template) {
-      throw Error(
-        `[${job.uid}] [action-mogrt-template] ERROR - no AE file found in the .mogrt (extension .aep)`
-      );
-    }
-
-    settings.logger.log(
-      `[${job.uid}] [action-mogrt-template] setting new template path to: ${template}`
-    );
-
-    job.template.dest = template;
-    job.template.extension = 'aep';
-    return job;
-  } else {
-    throw Error(
-      "'action-mogrt-template' module should be used only in 'predownload' section"
-    );
-  }
 };
+

--- a/package.json
+++ b/package.json
@@ -1,26 +1,27 @@
 {
-  "name": "nexrender-action-mogrt-template",
-  "version": "0.0.4",
-  "description": "MOGRT support for Nexrender",
-  "main": "index.js",
-  "scripts": {
-    "test": "node  --experimental-vm-modules ./node_modules/.bin/jest "
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/vonstring/nexrender-action-mogrt-template.git"
-  },
-  "author": "Kristian von Streng Hæhre",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/vonstring/nexrender-action-mogrt-template/issues"
-  },
-  "homepage": "https://github.com/vonstring/nexrender-action-mogrt-template#readme",
-  "dependencies": {
-    "mogrt": "^0.0.2",
-    "node-stream-zip": "^1.15.0"
-  },
-  "devDependencies": {
-    "jest": "^28.1.3"
-  }
+    "name": "nexrender-action-mogrt-template",
+    "version": "0.0.4",
+    "description": "MOGRT support for Nexrender",
+    "main": "index.js",
+    "scripts": {
+        "test": "node  --experimental-vm-modules ./node_modules/.bin/jest "
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/vonstring/nexrender-action-mogrt-template.git"
+    },
+    "author": "Kristian von Streng Hæhre",
+    "license": "ISC",
+    "bugs": {
+        "url": "https://github.com/vonstring/nexrender-action-mogrt-template/issues"
+    },
+    "homepage": "https://github.com/vonstring/nexrender-action-mogrt-template#readme",
+    "dependencies": {
+        "mogrt": "^0.0.2",
+        "node-stream-zip": "^1.15.0"
+    },
+    "devDependencies": {
+        "jest": "^28.1.3"
+    }
 }
+


### PR DESCRIPTION
First, this fixes a potential issue when a .Mogrt file has Groups. Originally, The **applyEssentialValues.jsx** script would not look recursively, and would miss properties inside groups.

Second, this branch allows for Media replacement in the Mogrt, using the `prop.setAlternatesource` method.
It also take care of transforming the file url one would use in Nexrender into a system path that would be understood by extendscript.

```js
 if (prop.canSetAlternateSource) {
                var replacementItem = app.project.importFile(
                    new ImportOptions(new File(value))
                );
                prop.setAlternateSource(replacementItem);
            } else {
                prop.setValue(value);
            }
```
            
           
A Job Json with Media replacement would look like this:

```json
{
  "template": {
    "src": "file:///path/to/file.mogrt",
    "composition": "Comp 1"
  },
  "actions": {
    "predownload": [
      {
        "module": "nexrender-action-mogrt-template",
        "essentialParameters": {
          "Intro_Text_Image": "file:///path/to/image.png",
          "Dog Name": "New Dog Name",
          "BG Color": [1, 1, 0, 1],
          "scale": [100, 100, 0]
        }
      }
    ]
  }
}
```